### PR TITLE
Fix typo in kate_plugins.py

### DIFF
--- a/kate_plugins/kate_plugins.py
+++ b/kate_plugins/kate_plugins.py
@@ -36,7 +36,7 @@ from pyte_plugins.text_plugins import *
 from pyte_plugins.check_plugins.parse_plugins import *
 
 try:
-    from pyte_plugins.check_plugins.cheack_all_plugins import *
+    from pyte_plugins.check_plugins.check_all_plugins import *
 except ImportError:
     pass
 try:


### PR DESCRIPTION
There is a typo in kate_plugins.py  that results in an ImportError.
